### PR TITLE
feat: add UI session management

### DIFF
--- a/src/core/sessions/uiSession.ts
+++ b/src/core/sessions/uiSession.ts
@@ -1,0 +1,77 @@
+const sessions = new Map<number, UiSessionState>();
+
+export interface UiSessionState {
+  screen?: string;
+  purpose?: string;
+  payload?: any;
+  lastUi?: {
+    chatId: number;
+    msgId: number;
+    purpose: string;
+  };
+}
+
+export function get(chatId: number): UiSessionState {
+  return sessions.get(chatId) || {};
+}
+
+export function set(chatId: number, partial: Partial<UiSessionState>): UiSessionState {
+  const current = sessions.get(chatId) || {};
+  const updated = { ...current, ...partial } as UiSessionState;
+  sessions.set(chatId, updated);
+  return updated;
+}
+
+export function clear(chatId: number) {
+  sessions.delete(chatId);
+}
+
+export async function showOrEdit(
+  ctx: any,
+  html: string,
+  kb: any,
+  purpose: string,
+  forceNew = false
+) {
+  const chatId = ctx.chat?.id;
+  if (!chatId) return;
+
+  const state = get(chatId);
+  const lastUi = state.lastUi;
+
+  if (!forceNew && lastUi && lastUi.purpose === purpose) {
+    try {
+      await ctx.api.editMessageText(lastUi.chatId, lastUi.msgId, html, {
+        parse_mode: "HTML",
+        reply_markup: kb
+      });
+      return;
+    } catch (e) {
+      // fall through to sending new message
+    }
+  }
+
+  if (lastUi) {
+    try {
+      await ctx.api.deleteMessage(lastUi.chatId, lastUi.msgId);
+    } catch (e) {
+      // ignore errors deleting old message
+    }
+  }
+
+  const msg = await ctx.reply(html, {
+    parse_mode: "HTML",
+    reply_markup: kb
+  });
+
+  set(chatId, {
+    lastUi: {
+      chatId: msg.chat.id,
+      msgId: msg.message_id,
+      purpose
+    }
+  });
+}
+
+
+export const uiSession = { get, set, clear, showOrEdit };


### PR DESCRIPTION
## Summary
- add in-memory UI session store
- support editing or replacing previous UI message based on purpose

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a508f4fc9883299f9be23078c03cd5