### PR TITLE
docs: document PORT and NODE_ENV

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -71,5 +71,7 @@ Required for deployment:
 
 Optional:
 - `DEBUG=1` - Enable polling mode for local development
+- `PORT=5000` - Server port (defaults to 5000)
+- `NODE_ENV=production` - Production optimizations
 
 The deployment will automatically set `PUBLIC_URL` or use `REPL_URL` for webhooks.

--- a/README.md
+++ b/README.md
@@ -53,9 +53,12 @@ MASTER_KMS_KEY=base64_encoded_32_byte_key
 
 # Optional
 DEBUG=1 # enable polling locally
+PORT=5000
+NODE_ENV=production
 FEE_TREASURY_SECRET=base58_fee_treasury_private_key
 FEE_BPS=50
 FEE_MIN_RAW_SOL=5000
 OWNER_TELEGRAM_ID=your_telegram_id
 SPONSOR_FEES=true
 ESCROW_EXPIRY_HOURS=168
+```

--- a/deployment-instructions.md
+++ b/deployment-instructions.md
@@ -38,6 +38,8 @@ curl -s "https://api.telegram.org/bot<YOUR_BOT_TOKEN>/getWebhookInfo"
 - `HELIUS_API_KEY`: Your Helius API key
 - `MASTER_KMS_KEY`: 32-byte encryption key (base64)
 - `DEBUG` (optional): Set to `1` to enable polling locally
+- `PORT=5000` (optional): Server port
+- `NODE_ENV=production` (optional): Production optimizations
 
 ## Troubleshooting
 - If bot doesn't respond, check webhook URL is correct and HTTPS

--- a/deployment.md
+++ b/deployment.md
@@ -48,8 +48,9 @@ npx prisma generate && npx prisma db push && npx tsx server/index.ts
 - `DATABASE_URL` - PostgreSQL connection string
 
 **Optional**:
-- `DEBUG=1` - Enable polling mode for local development
+- `PORT=5000` - Server port (defaults to 5000)
 - `NODE_ENV=production` - Production optimizations
+- `DEBUG=1` - Enable polling mode for local development
 - `OWNER_TELEGRAM_ID` - Bot owner for admin commands
 
 ### Verification


### PR DESCRIPTION
## Summary
- document PORT=5000 and NODE_ENV=production in main README
- sync deployment guides with consistent environment variable requirements

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a533c739c083299c68090746775da2